### PR TITLE
Resolve Travis build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ language: scala
 matrix:
   include:
     # scala 2.10
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       scala: 2.10.7
     # scala 2.11
-    - jdk: oraclejdk8
+    - jdk: openjdk8
       scala: 2.11.12
     # scala 2.12
-    - jdk: oraclejdk8
-      scala: 2.12.4
+    - jdk: openjdk8
+      scala: 2.12.10
 
 branches:
   only:
@@ -39,8 +39,8 @@ cache:
     - $HOME/.sbt/boot/scala-$TRAVIS_SCALA_VERSION
 
 after_success:
-  - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+  - find $HOME/.sbt -name "*.lock" -type f -delete
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
   # - "bash <(curl -s https://codecov.io/bash) -r $TRAVIS_REPO_SLUG -t $CODECOV_TOKEN"
 
 env:


### PR DESCRIPTION
In https://github.com/getnelson/quiver/pull/1 I was running into some
issues with the Travis build. This PR attempts to fix those issues
separately from the core of that PR.

One issue seems to be related to Oracle JDK licensing. See [this Travis forum post](https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038). Switching to openjdk seemed like a reasonable solution.

The other issue came about in builds where there were no files matching
`ivydata-*.properties`, so a find that was piping those into `rm` was
failing. This uses the `-delete` flag for `find` which shouldn't fail if
no files are found.